### PR TITLE
man: fix section headers

### DIFF
--- a/man/composefs-dump.md
+++ b/man/composefs-dump.md
@@ -1,4 +1,4 @@
-% composefs-dump(5) composefs | User Commands
+% composefs-dump 5 "" composefs "User Commands"
 
 # NAME
 

--- a/man/composefs-info.md
+++ b/man/composefs-info.md
@@ -1,4 +1,4 @@
-% composefs-info(1) composefs | User Commands
+% composefs-info 1 "" composefs "User Commands"
 
 # NAME
 

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later OR Apache-2.0
 manuals = {
     '1': [
-        'mount.composefs',
         'mkcomposefs',
         'composefs-info',
     ],
     '5': [
         'composefs-dump',
+    ],
+    '8': [
+        'mount.composefs',
     ],
 }
 

--- a/man/mkcomposefs.md
+++ b/man/mkcomposefs.md
@@ -1,4 +1,4 @@
-% mkcomposefs(1) composefs | User Commands
+% mkcomposefs 1 "" composefs "User Commands"
 
 # NAME
 

--- a/man/mount.composefs.md
+++ b/man/mount.composefs.md
@@ -1,4 +1,4 @@
-% mount.composefs(1) composefs | User Commands
+% mount.composefs 1 "" composefs "User Commands"
 
 # NAME
 

--- a/man/mount.composefs.md
+++ b/man/mount.composefs.md
@@ -1,4 +1,4 @@
-% mount.composefs 1 "" composefs "User Commands"
+% mount.composefs 8 "" composefs "User Commands"
 
 # NAME
 


### PR DESCRIPTION
While packaging for Debian, lintian complained about the section headers:

```
W: composefs: wrong-manual-section 1 != composefs [usr/share/man/man1/composefs-info.1.gz:2]
W: composefs: wrong-manual-section 1 != composefs [usr/share/man/man1/mkcomposefs.1.gz:2]
W: composefs: wrong-manual-section 1 != composefs [usr/share/man/man1/mount.composefs.1.gz:2]
W: composefs: wrong-manual-section 5 != composefs [usr/share/man/man5/composefs-dump.5.gz:2]
```

(See <https://lintian.debian.org/tags/wrong-manual-section.html> for full info about the warning.)

According to man-pages(7), the .TH syntax is:

```
.TH title section date source manual-section
```

Remove the parentheses so that the section is detected correctly, leave the date empty, and escape the space in the last argument to comform to the required syntax.