### PR TITLE
tests: increase check-checksums timeout to 300 seconds

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -67,7 +67,7 @@ endforeach
 tools_dir = meson.current_build_dir() / '../tools'
 
 test('check-units', find_program('test-units.sh'), args : [tools_dir])
-test('check-checksums', find_program('test-checksums.sh'), args : [tools_dir, meson.current_source_dir() / 'assets', ' '.join(test_assets)])
+test('check-checksums', find_program('test-checksums.sh'), args : [tools_dir, meson.current_source_dir() / 'assets', ' '.join(test_assets)], timeout : 300)
 test('check-dump-filtered', find_program('test-dump-filtered.sh'), args : [tools_dir, meson.current_source_dir() / 'assets'])
 test('check-random-fuse', find_program('test-random-fuse.sh'), args : [tools_dir], timeout : 300)
 should_fail_args = [tools_dir]


### PR DESCRIPTION
Meson applies a default timeout of 30 seconds to all tests ([source](https://mesonbuild.com/Unit-tests.html#other-test-options%3E)). Since the check-checksums test is quite I/O-heavy, this might lead to timeouts in CI builds depending on the load of the build machines. Increase it to 300 seconds (same as check-random-fuse) to be on the safe side.