### PR TITLE
mkcomposefs: handle failed_path NULL from lcfs_build()

### DIFF
--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -1690,8 +1690,11 @@ int main(int argc, char **argv)
 		buildflag_copy |= LCFS_BUILD_NO_INLINE;
 
 		root = lcfs_build(AT_FDCWD, src_path, buildflag_copy, &failed_path);
-		if (root == NULL)
-			err(EXIT_FAILURE, "error accessing %s", failed_path);
+		if (root == NULL) {
+			// An allocation error in maybe_join_path() can cause
+			// failed_path to be set to NULL
+			err(EXIT_FAILURE, "error accessing %s", failed_path ?: "");
+		}
 
 		if (compute_digest(threads, root, src_path, buildflags) < 0)
 			err(EXIT_FAILURE, "error computing digest");


### PR DESCRIPTION
`lcfs_build()` might have set `failed_path` to `NULL`. This could happen if `maybe_join_path()` returns `NULL` due to a `malloc()` failure. If this happens, use an empty string to avoid segfaulting in `err()`.

I spotted this when I was reading the code. I hope the analysis is correct. I think it's better to use the somewhat confusing error message `error accessing` than seqfaulting.