### PR TITLE
Add CNCF copyright footer text

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,6 @@ that could in theory be extracted to a helper package.
 
 We have a dedicated [CONTRIBUTING](CONTRIBUTING.md) document.
 
+## Copyright
+
+Copyright © contributors to composefs, established as composefs a Series of LF Projects, LLC.


### PR DESCRIPTION
This addresses the footer item in the [composefs CNCF sandbox onboarding task](https://github.com/cncf/sandbox/issues/340). 

It's also covered in the Contribution Agreement instructions.