### PR TITLE
lcfs-fsverity: fix root_hash for zero-length files

### DIFF
--- a/libcomposefs/lcfs-fsverity.c
+++ b/libcomposefs/lcfs-fsverity.c
@@ -432,8 +432,6 @@ void lcfs_fsverity_context_get_digest(FsVerityContext *ctx,
 {
 	struct fsverity_descriptor descriptor;
 
-	lcfs_fsverity_context_flush_level(ctx, 0);
-
 	memset(&descriptor, 0, sizeof(descriptor));
 	descriptor.version = 1;
 	descriptor.hash_algorithm = 1;
@@ -441,8 +439,15 @@ void lcfs_fsverity_context_get_digest(FsVerityContext *ctx,
 	descriptor.salt_size = 0;
 	descriptor.data_size_le = htole64(ctx->file_size);
 
-	do_sha256(ctx, ctx->buffer[ctx->max_level], FSVERITY_BLOCK_SIZE,
-		  descriptor.root_hash);
+	/* An empty file has zero Merkle tree blocks, so per the fs-verity
+	 * on-disk format root_hash stays all-zero (as set by the memset
+	 * above). There is nothing to flush or hash in that case. */
+	if (ctx->file_size > 0) {
+		lcfs_fsverity_context_flush_level(ctx, 0);
+
+		do_sha256(ctx, ctx->buffer[ctx->max_level], FSVERITY_BLOCK_SIZE,
+			  descriptor.root_hash);
+	}
 
 	do_sha256(ctx, (uint8_t *)&descriptor, sizeof(descriptor), digest);
 }

--- a/tests/test-lcfs.c
+++ b/tests/test-lcfs.c
@@ -244,6 +244,29 @@ static void test_no_verity(void)
 	close(tmpfd);
 }
 
+// Regression test for https://github.com/composefs/composefs/issues/442.
+//
+// A zero-length file has no Merkle tree blocks, so the root_hash field
+// inside the fsverity_descriptor must be all-zero. The final digest
+// below is *not* that root_hash: it's SHA256(descriptor), i.e. what
+// lcfs_compute_fsverity_from_data() / `composefs-info measure-file`
+// actually returns, and what the kernel reports via `fsverity measure`
+// for a real empty file with fs-verity enabled.
+static void test_fsverity_empty_file(void)
+{
+	static const uint8_t expected[LCFS_DIGEST_SIZE] = {
+		0x3d, 0x24, 0x8c, 0xa5, 0x42, 0xa2, 0x4f, 0xc6,
+		0x2d, 0x1c, 0x43, 0xb9, 0x16, 0xea, 0xe5, 0x01,
+		0x68, 0x78, 0xe2, 0x53, 0x3c, 0x88, 0x23, 0x84,
+		0x80, 0xb2, 0x61, 0x28, 0xa1, 0xf1, 0xaf, 0x95,
+	};
+	uint8_t digest[LCFS_DIGEST_SIZE];
+
+	int r = lcfs_compute_fsverity_from_data(digest, NULL, 0);
+	assert(r == 0);
+	assert(memcmp(digest, expected, LCFS_DIGEST_SIZE) == 0);
+}
+
 int main(int argc, char **argv)
 {
 	(void)argc;
@@ -255,4 +278,5 @@ int main(int argc, char **argv)
 	test_xattr_addremove();
 	test_xattr_doubleadd();
 	test_hardlinked_whiteout_load();
+	test_fsverity_empty_file();
 }


### PR DESCRIPTION
lcfs_fsverity_context_get_digest() unconditionally zero-padded and hashed a full Merkle tree block to produce root_hash, even for zero-length files. Per the fs-verity on-disk format, an empty file has zero Merkle tree blocks, so root_hash must be all-zero bytes instead.

This meant composefs-info measure-file (and any direct caller of lcfs_fsverity_context_get_digest with empty input) reported a digest the kernel, fsverity-utils, and composefs-rs's independent reimplementation can never produce, even though composefs images themselves are unaffected since they never reference empty backing objects.

Assisted-by: https://github.com/cgwalters/cgwalters#llms
Closes: #442